### PR TITLE
Support external volume for docker root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ as a Kubernetes master for other nodes!
       
 Congratulations, you have a working multi-node Kubernetes cluster! You can
 repeat these steps to add as many new nodes as you want :)
+
+## Docker Storage Base Directory
+By default, Docker puts all of the images and other work files in a directory
+on the boot volume of the instance, called `/var/lib/docker`. This is quite
+convenient for a simple trial system, but this directory can easily fill up
+causing disastrous results for your cluster.
+
+It is highly recommended that you mount an external volume as `/var/lib/docker`
+on each host before running the bootstrap script. Don't forget to configure this
+mount to be restored upon reboot or else docker will quietly create a new
+directory and start storing the files on your boot volume as a ticking time
+bomb.
    
 ## Next step?
 


### PR DESCRIPTION
# Problem
Docker installations that rely on the boot volume for docker images and overlay file system are vulnerable to running out of disk space. 

# Approach
Allow users of Kubeadm-bootstrap to mount a volume to the host and provide the device id to the bootstrap script. It formats the drive and mounts it to `/opt/docker`.  

While the docker service is stopped, it adds a line to `/etc/docker/daemon.json` to set the `graph` property to this new mount. This instructs the docker daemon to use this instead of `/var/lib/docker`.

Finally, the script adds an entry to this new mount to fstab to insure the mount remains available after a server reboot.

These steps only occur if the device ID is provided as a command line argument. If no argument is provided then these steps are skipped and docker will continue with the directory on the boot volume.

_Note_ in docker version 18, the `graph` property was deprecated in favor of a new property called `data-root`. The bootstrap script explicitly uses docker version 17.03. When we upgrade docker, we will need to change this property.

# How to Test
1. Provision a host with an attached 75Gb volume. Run the bootstrap script with the device ID for this volume as an argument. Once complete verify that docker is running correctly: `sudo docker ps`. The look in `/opt/docker` to see that the volume was mounted there and it contains the usual docker directories. Use `df .` command in `/opt/docker` to see that the file system was indeed mounted there.

2. Insure that the argument is optional by provisioning a new host and running the bootstrap script without no argument. Insure that docker is running correctly.

